### PR TITLE
[CLI] Adds CLI to the buildpack

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -40,8 +40,6 @@ function json_value() {
 BUILD_DIR=$1
 CACHE_DIR=$2
 ENV_DIR=$3
-export LIBRARY_PATH=/app/.heroku/vendor/lib:$BUILD_DIR/.heroku/vendor/lib:/app/.heroku/python/lib:$LIBRARY_PATH
-export LD_LIBRARY_PATH=/app/.heroku/vendor/lib:$BUILD_DIR/.heroku/vendor/lib:/app/.heroku/python/lib:$LD_LIBRARY_PATH
 
 if [ -f $BUILD_DIR/.crystal-version ]; then
   CRYSTAL_VERSION=`cat $BUILD_DIR/.crystal-version | tr -d '\012'`

--- a/bin/compile
+++ b/bin/compile
@@ -80,7 +80,7 @@ PATH="${PATH}:${BUILD_DIR}/bin"
 cd $BUILD_DIR
 
 start "Building src/${shard_name}.cr (auto-detected from shard.yml)"
-  AMBER_ENV=production crystal build --release --no-debug src/${shard_name}.cr
+  AMBER_ENV=production crystal build --release --no-debug src/${shard_name}.cr -o bin/${shard_name}
 finished
 
 # Export shard_name to be used by release script

--- a/bin/compile
+++ b/bin/compile
@@ -81,6 +81,7 @@ cd $BUILD_DIR
 
 start "Building src/${shard_name}.cr (auto-detected from shard.yml)"
   AMBER_ENV=production crystal build --release --no-debug src/${shard_name}.cr -o bin/${shard_name}
+  chmod +x $BUILD_DIR/bin/${shard_name}
 finished
 
 # Export shard_name to be used by release script

--- a/bin/compile
+++ b/bin/compile
@@ -40,6 +40,8 @@ function json_value() {
 BUILD_DIR=$1
 CACHE_DIR=$2
 ENV_DIR=$3
+export LIBRARY_PATH=/app/.heroku/vendor/lib:$BUILD_DIR/.heroku/vendor/lib:/app/.heroku/python/lib:$LIBRARY_PATH
+export LD_LIBRARY_PATH=/app/.heroku/vendor/lib:$BUILD_DIR/.heroku/vendor/lib:/app/.heroku/python/lib:$LD_LIBRARY_PATH
 
 if [ -f $BUILD_DIR/.crystal-version ]; then
   CRYSTAL_VERSION=`cat $BUILD_DIR/.crystal-version | tr -d '\012'`
@@ -63,8 +65,24 @@ PATH="${PATH}:${CRYSTAL_DIR}/bin"
 # Build the Amber project
 cd $BUILD_DIR
 eval $(parse_yaml shard.yml "shard_")
+
+start "Building amber CLI"
+  crystal deps
+  cd $BUILD_DIR/lib/amber
+  sed -in "4d" $BUILD_DIR/lib/amber/src/amber/cli/commands/database.cr
+  sed -in "4d" $BUILD_DIR/lib/amber/src/amber/cli/commands/migrate.cr
+  sed -in "68,70d" $BUILD_DIR/lib/amber/shard.yml
+  crystal deps
+  mkdir -p $BUILD_DIR/bin
+  crystal build --no-debug -o $BUILD_DIR/bin/amber $BUILD_DIR/lib/amber/src/amber/cli.cr
+finished
+
+chmod +x $BUILD_DIR/bin/amber
+PATH="${PATH}:${BUILD_DIR}/bin"
+cd $BUILD_DIR
+
 start "Building src/${shard_name}.cr (auto-detected from shard.yml)"
-  AMBER_ENV=production crystal deps build --production --no-debug ${shard_name}
+  AMBER_ENV=production crystal build --release --no-debug src/${shard_name}.cr
 finished
 
 # Export shard_name to be used by release script

--- a/bin/compile
+++ b/bin/compile
@@ -80,7 +80,7 @@ PATH="${PATH}:${BUILD_DIR}/bin"
 cd $BUILD_DIR
 
 start "Building src/${shard_name}.cr (auto-detected from shard.yml)"
-  AMBER_ENV=production crystal build --release --no-debug src/${shard_name}.cr -o bin/${shard_name}
+  AMBER_ENV=production crystal build --release --no-debug $BUILD_DIR/src/${shard_name}.cr -o $BUILD_DIR/bin/${shard_name}
   chmod +x $BUILD_DIR/bin/${shard_name}
 finished
 


### PR DESCRIPTION

<img width="880" alt="screen shot 2017-12-20 at 4 05 53 pm" src="https://user-images.githubusercontent.com/1685772/34228738-ba52d644-e59f-11e7-87cb-178be7fcb1ee.png">
This compiles the Amber CLI by removing the sqliite3 dependencies

Usage

```
$ heroku run bin/amber -v
$ Amber CLI (amberframework.org) - v0.3.7
```