### PR TITLE
Prevent yaml sed

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -73,7 +73,6 @@ if [ ! -e "$amber_executable" ]; then
     start "Installing amber CLI"
       cd $BUILD_DIR/lib/amber
       sed -in "4d" $BUILD_DIR/lib/amber/src/amber/cli/commands/database.cr
-      sed -in "68,70d" $BUILD_DIR/lib/amber/shard.yml
       crystal deps update
       mkdir -p $BUILD_DIR/bin
       echo -e "\n"


### PR DESCRIPTION
`sed` command causes a problem described here: https://github.com/veelenga/ameba/issues/30#issuecomment-359164678

I believe that was an attempt to remove  SQLite shard from the dependencies since Heroku doesn't support SQLite.

But this buildpack still works for me even with included SQLite dependency (unless I require it somewhere).