### PR TITLE
compile and install all shard targets rather than just the shard name

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -94,10 +94,12 @@ PATH="${PATH}:${BUILD_DIR}/bin"
 cd $BUILD_DIR
 eval $(parse_yaml shard.yml "shard_")
 
-start "Building src/${shard_name}.cr (auto-detected from shard.yml)"
-  AMBER_ENV=production crystal build --release --no-debug --stats $BUILD_DIR/src/${shard_name}.cr -o $BUILD_DIR/bin/${shard_name}
-  chmod +x $BUILD_DIR/bin/${shard_name}
-finished
+for target in $(compgen -A variable | grep shard_targets | sed 's/shard_targets_\(.*\)_main/\1/g'); do
+  start "Building src/${target}.cr (auto-detected from shard.yml)"
+    AMBER_ENV=production crystal build --release --no-debug $BUILD_DIR/src/${target}.cr -o $BUILD_DIR/bin/${target}
+    chmod +x $BUILD_DIR/bin/${target}
+  finished
+done
 
 # Export shard_name to be used by release script
 echo ${shard_name} > /tmp/shard_name


### PR DESCRIPTION
Given the (understandable) lack of REPL all the way up the chain through Crystal, we opted to create a second compilation target for one-off scripts. We found this patch useful for building them. Not sure if Amber has a solution in mind for this, so here's ours :)

The implicit assumption here (which I want to call out as possibly tenuous since I'm very new to crystal) is that the shard name would match one of the target names. https://github.com/amberframework/amber/blob/master/src/amber/cli/templates/app/shard.yml.ecr#L12 indicated to me that this was an at-least-presently-OK solution.